### PR TITLE
Add missing parameters to Google Maps SERP tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ pnpm-debug.log*
 # Editor directories and files
 .vscode/
 .idea/
+.claude/
+.mcp.json
 *.swp
 *.swo
 *~

--- a/src/api/serp/index.ts
+++ b/src/api/serp/index.ts
@@ -99,6 +99,10 @@ export function registerSerpTools(server: McpServer, apiClient: DataForSeoClient
     server,
     "serp_google_maps_live",
     googleOrganicLiveSchema.extend({
+      location_name: z.string().optional().describe("Full name of the location (e.g., 'London,England,United Kingdom')"),
+      location_code: z.number().optional().describe("The location code for the search (optional if location_coordinate provided)"),
+      location_coordinate: z.string().optional().describe("GPS coordinates as 'latitude,longitude,zoom' (e.g., '51.5074,-0.1278,15z'). Use for point-specific rankings."),
+      search_this_area: z.boolean().optional().describe("Restrict results to the displayed map area"),
       local_pack_type: z.enum(["maps", "local_pack"]).optional().describe("Type of local pack results")
     }),
     async (params, client) => {


### PR DESCRIPTION
## Summary

Adds missing parameters to the `serp_google_maps_live` tool to support GPS-based location searches.

## Changes

**New parameters for `serp_google_maps_live`:**
- `location_name` - Full name of the location (e.g., 'London,England,United Kingdom')
- `location_code` - Made optional (can use coordinate instead)
- `location_coordinate` - GPS coordinates as 'latitude,longitude,zoom' (e.g., '51.5074,-0.1278,15z')
- `search_this_area` - Restrict results to the displayed map area

**Other:**
- Added `.claude/` and `.mcp.json` to .gitignore

## Tested

Verified working with the MCP tool - searched for "coffee shops" near Trafalgar Square using `location_coordinate` and `search_this_area` parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)